### PR TITLE
Add mockable tx

### DIFF
--- a/activerecord/activerecord.go
+++ b/activerecord/activerecord.go
@@ -552,3 +552,8 @@ func (ar *ActiveRecord) GetTokens() []string {
 func (ar *ActiveRecord) GetArgs() []interface{} {
 	return ar.Args
 }
+
+// Begin begin a real transaction
+func (ar *ActiveRecord) Begin() (MockableTx, error) {
+	return ar.DB.Begin()
+}

--- a/activerecord/fake_activerecord.go
+++ b/activerecord/fake_activerecord.go
@@ -6,8 +6,10 @@ import "database/sql"
 type FakeActiveRecord struct {
 	*ActiveRecord
 	MockGetRows func() ([]map[string]interface{}, error)
-	MockGetRow  func(tokens []string) (map[string]interface{}, error)
+	MockGetRow func(tokens []string) (map[string]interface{}, error)
 	MockExecSQL func(sql string, args ...interface{}) (sql.Result, error)
+	MockBegin   func() (MockableTx, error)
+	MockClose   func()
 }
 
 // NewFakeActiveRecord return a *FakeActiveRecord
@@ -18,7 +20,11 @@ func NewFakeActiveRecord() *FakeActiveRecord {
 		return nil, nil
 	}, func(sql string, args ...interface{}) (sql.Result, error) {
 		return nil, nil
-	}}
+	}, func() (MockableTx, error) {
+		return nil, nil
+	},
+		func() {},
+	}
 }
 
 // GetRows will call MockGetRows in MockActiveRecord if it is set
@@ -43,4 +49,19 @@ func (m *FakeActiveRecord) ExecSQL(sql string, args ...interface{}) (sql.Result,
 		return m.MockExecSQL(sql, args)
 	}
 	return nil, nil
+}
+
+// Begin will call Begin if it is set
+func (m *FakeActiveRecord) Begin() (MockableTx, error) {
+	if m.MockBegin != nil {
+		return m.MockBegin()
+	}
+	return nil, nil
+}
+
+// Begin will call Begin if it is set
+func (m *FakeActiveRecord) Close() {
+	if m.MockClose != nil {
+		m.MockClose()
+	}
 }

--- a/activerecord/fake_tx.go
+++ b/activerecord/fake_tx.go
@@ -1,0 +1,46 @@
+package activerecord
+
+import "database/sql"
+
+// FakeActiveRecord is only for test. You can change MockGetRows to return your own data
+type FakeTx struct {
+	*sql.Tx
+	MockExec     func(query string, args ...interface{}) (sql.Result, error)
+	MockRollback func() (error)
+	MockCommit   func() (error)
+}
+
+// NewFakeTx return a *FakeTx
+func NewFakeTx() *FakeTx {
+	return &FakeTx{&sql.Tx{}, func(query string, args ...interface{}) (sql.Result, error) {
+		return nil, nil
+	}, func() (error) {
+		return nil
+	}, func() (error) {
+		return nil
+	}}
+}
+
+// Exec will call MockExec in FakeTx if it is set
+func (m *FakeTx) Exec(query string, args ...interface{}) (sql.Result, error) {
+	if m.MockExec != nil {
+		return m.MockExec(query, args)
+	}
+	return nil, nil
+}
+
+// Rollback will call Rollback in FakeTx if it is set
+func (m *FakeTx) Rollback() (error) {
+	if m.MockRollback != nil {
+		return m.MockRollback()
+	}
+	return nil
+}
+
+// ExecSQL will call Commit if it is set
+func (m *FakeTx) Commit() (error) {
+	if m.MockCommit != nil {
+		return m.MockCommit()
+	}
+	return nil
+}

--- a/activerecord/mockable_ar.go
+++ b/activerecord/mockable_ar.go
@@ -55,4 +55,5 @@ type MockableActiveRecord interface {
 	SubAR(sub MockableActiveRecord, alias string) string
 	ArgsString() string
 	PrintableString() string
+	Begin() (MockableTx, error)
 }

--- a/activerecord/mockable_tx.go
+++ b/activerecord/mockable_tx.go
@@ -1,0 +1,12 @@
+package activerecord
+
+import (
+	"database/sql"
+)
+
+// MockableTx is a mock TX for test usage
+type MockableTx interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	Rollback() error
+	Commit() error
+}


### PR DESCRIPTION
Sometimes we directly use activeRecord.DB to start a transcation
, then submit queries in database, which makes mockActiveRecord not
enough for test. So this commit adds mockableTx to make sql.Tx fakeable
@violet2016 Please help review the change if you have time